### PR TITLE
Update about page icons

### DIFF
--- a/about.md
+++ b/about.md
@@ -8,8 +8,8 @@ permalink: /about/
 
 You can find my research profiles and publications at the links below:
 
-- [ORCID: 0000-0001-6673-3432](https://orcid.org/0000-0001-6673-3432)
-- [NASA ADS Publications](https://ui.adsabs.harvard.edu/search/q=orcid%3A0000-0001-6673-3432&sort=date%20desc,%20bibcode%20desc&p_=0)
-- [Google Scholar](https://scholar.google.com/citations?user=yF0j6J8AAAAJ)
-- [arXiv Preprints](https://arxiv.org/a/alterman_b_1)
-- [GitHub](https://github.com/blalterman)
+- [![ORCID icon](/assets/images/orcid/ORCID-iD_icon_24x24.png) ORCID: 0000-0001-6673-3432](https://orcid.org/0000-0001-6673-3432)
+- [![ADS logo](/assets/images/ads/ads.svg) NASA ADS Publications](https://ui.adsabs.harvard.edu/search/q=orcid%3A0000-0001-6673-3432&sort=date%20desc,%20bibcode%20desc&p_=0)
+- [![Google Scholar logo](/assets/images/google-scholar/google-scholar.svg) Google Scholar](https://scholar.google.com/citations?user=yF0j6J8AAAAJ)
+- [![arXiv logo](/assets/images/arxiv/arxiv.svg) arXiv Preprints](https://arxiv.org/a/alterman_b_1)
+- [![GitHub logo](/assets/images/github/github-mark.svg) GitHub](https://github.com/blalterman)


### PR DESCRIPTION
## Summary
- add organization icons to About page links

## Testing
- `markdownlint about.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688aed419a44832cbd622e846e02a5b7