### PR TITLE
Fix icon sizes on about page

### DIFF
--- a/about.md
+++ b/about.md
@@ -8,8 +8,8 @@ permalink: /about/
 
 You can find my research profiles and publications at the links below:
 
-- [![ORCID icon](/assets/images/orcid/ORCID-iD_icon_24x24.png) ORCID: 0000-0001-6673-3432](https://orcid.org/0000-0001-6673-3432)
-- [![ADS logo](/assets/images/ads/ads.svg) NASA ADS Publications](https://ui.adsabs.harvard.edu/search/q=orcid%3A0000-0001-6673-3432&sort=date%20desc,%20bibcode%20desc&p_=0)
-- [![Google Scholar logo](/assets/images/google-scholar/google-scholar.svg) Google Scholar](https://scholar.google.com/citations?user=yF0j6J8AAAAJ)
-- [![arXiv logo](/assets/images/arxiv/arxiv.svg) arXiv Preprints](https://arxiv.org/a/alterman_b_1)
-- [![GitHub logo](/assets/images/github/github-mark.svg) GitHub](https://github.com/blalterman)
+- <a href="https://orcid.org/0000-0001-6673-3432"><img src="/assets/images/orcid/ORCID-iD_icon_24x24.png" alt="ORCID icon" width="24" height="24"> ORCID: 0000-0001-6673-3432</a>
+- <a href="https://ui.adsabs.harvard.edu/search/q=orcid%3A0000-0001-6673-3432&sort=date%20desc,%20bibcode%20desc&p_=0"><img src="/assets/images/ads/ads.svg" alt="ADS logo" width="24" height="24"> NASA ADS Publications</a>
+- <a href="https://scholar.google.com/citations?user=yF0j6J8AAAAJ"><img src="/assets/images/google-scholar/google-scholar.svg" alt="Google Scholar logo" width="24" height="24"> Google Scholar</a>
+- <a href="https://arxiv.org/a/alterman_b_1"><img src="/assets/images/arxiv/arxiv.svg" alt="arXiv logo" width="24" height="24"> arXiv Preprints</a>
+- <a href="https://github.com/blalterman"><img src="/assets/images/github/github-mark.svg" alt="GitHub logo" width="24" height="24"> GitHub</a>


### PR DESCRIPTION
## Summary
- use explicit `<img>` tags with width and height to standardize icons

## Testing
- `markdownlint --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688af1749860832c96558292edd08847