### PR TITLE
Update ADS metrics workflow to pull before push

### DIFF
--- a/.github/workflows/update-ads-metrics.yml
+++ b/.github/workflows/update-ads-metrics.yml
@@ -29,10 +29,15 @@ jobs:
         run: |
           python scripts/fetch_ads_metrics_to_data_dir.py --orcid 0000-0001-6673-3432
 
+      - name: Pull latest changes
+        run: |
+          git fetch origin
+          git pull origin main --ff-only
+
       - name: Commit updated metrics file
         run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
           git add _data/ads_metrics.json
           git commit -m "Update ADS metrics [automated]" || echo "No changes to commit"
-          git push
+          git push origin main


### PR DESCRIPTION
## Summary
- ensure the `update-ads-metrics` workflow pulls from `main` before committing
- push explicitly to `origin main`

## Testing
- `pip install yamllint --quiet` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_688af90537f0832ca26f4e2ae55edb79