### PR TITLE
Update GitHub workflow for ADS publications

### DIFF
--- a/.github/workflows/update-ads-publications.yml
+++ b/.github/workflows/update-ads-publications.yml
@@ -29,12 +29,15 @@ jobs:
         run: |
           python scripts/fetch_ads_publications_to_data_dir.py
 
-      - name: Commit updated publications JSON
+      - name: Pull latest changes
+        run: |
+          git fetch origin
+          git pull origin main --ff-only
+
+      - name: Commit updated publications file
         run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
-          git fetch origin
-          git pull origin main --ff-only
           git add _data/ads_publications.json
           git commit -m "Update ADS publications [automated]" || echo "No changes to commit"
           git push origin main


### PR DESCRIPTION
## Summary
- pull latest in the publications workflow before committing
- commit updated publications file with explicit step

## Testing
- `yamllint .github/workflows/update-ads-publications.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688afd61d678832cbcbc3abf03d61d9d