### PR TITLE
Add headshot to header

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,7 @@
 
 # Site settings
 title: B. L. Alterman
+logo: "/assets/images/headshot.jpg"
 baseurl: ""
 url: ""
 

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -1,0 +1,1 @@
+<link rel="stylesheet" href="{{ '/assets/css/custom.css' | relative_url }}">

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,0 +1,3 @@
+img.site-logo {
+  border-radius: 50%;
+}


### PR DESCRIPTION
## Summary
- show a headshot logo in the site header
- include custom stylesheet to make the image round

## Testing
- ❌ `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688b043e4ea8832cae3352471f4a7757