### PR TITLE
Fix publication year display

### DIFF
--- a/_includes/publication_entry.liquid
+++ b/_includes/publication_entry.liquid
@@ -23,7 +23,7 @@
 <li>
   <strong><a href="{{ pub.url }}" target="_blank" rel="noopener">{{ pub.title }}</a></strong><br>
   <span class="authors">{{ formatted_authors }}</span><br>
-  <em>{{ pub.journal }}</em>, {{ pub.year | date: '%Y' }}.
+  <em>{{ pub.journal }}</em>, {{ pub.year | slice: 0, 4 }}.
   {% if pub.citations and pub.citations > 0 %}
     <span class="citations"> Citations: {{ pub.citations }}</span>
   {% endif %}

--- a/publications.md
+++ b/publications.md
@@ -4,7 +4,7 @@ title: Publications
 permalink: /publications/
 ---
 
-## Statistics 
+## Statistics
 
 This page is automatically generated using data from [NASA ADS](https://ui.adsabs.harvard.edu) and is updated weekly.
 
@@ -14,7 +14,6 @@ This page is automatically generated using data from [NASA ADS](https://ui.adsab
 - **Refereed papers**: {{ site.data.ads_metrics["basic stats refereed"]["number of papers"] }}
 - **Refereed citations**: {{ site.data.ads_metrics["citation stats refereed"]["total number of citations"] }}
 
-
 ## Publication List
 
 {% assign pubs_by_type = site.data.ads_publications | group_by: "publication_type" %}
@@ -22,11 +21,11 @@ This page is automatically generated using data from [NASA ADS](https://ui.adsab
 {% assign other_groups = "" | split: "" %}
 
 {% for group in pubs_by_type %}
-  {% if group.name == "inproceedings" or group.name == "abstracts" %}
-    {% assign combined_groups = combined_groups | concat: group.items %}
-  {% else %}
-    {% assign other_groups = other_groups | push: group %}
-  {% endif %}
+{% if group.name == "inproceedings" or group.name == "abstracts" %}
+{% assign combined_groups = combined_groups | concat: group.items %}
+{% else %}
+{% assign other_groups = other_groups | push: group %}
+{% endif %}
 {% endfor %}
 
 {% assign sorted_other_groups = other_groups | sort: "name" %}
@@ -40,6 +39,7 @@ This page is automatically generated using data from [NASA ADS](https://ui.adsab
 </ul>
 
 {% for group in sorted_other_groups %}
+
   <h2>{{ group.name | capitalize }}</h2>
   <ul class="publication-list">
     {% assign pubs = group.items | sort: "year" | reverse %}


### PR DESCRIPTION
## Summary
- format publication year to show only the year
- run Prettier on updated markdown

## Testing
- `npx prettier -w _includes/publication_entry.liquid publications.md`

------
https://chatgpt.com/codex/tasks/task_e_688b0f5c83e0832cb9da629344f9f9eb