### PR TITLE
Fix 'Eprint' heading

### DIFF
--- a/publications.md
+++ b/publications.md
@@ -40,7 +40,11 @@ This page is automatically generated using data from [NASA ADS](https://ui.adsab
 </ul>
 
 {% for group in sorted_other_groups %}
+  {% if group.name == "eprint" %}
+  <h2>Pre-Prints</h2>
+  {% else %}
   <h2>{{ group.name | capitalize }}</h2>
+  {% endif %}
   <ul class="publication-list">
     {% assign pubs = group.items | sort: "year" | reverse %}
     {% for pub in pubs %}


### PR DESCRIPTION
## Summary
- update publications page to show `Pre-Prints` for the eprint group

## Testing
- `prettier --write publications.md`

------
https://chatgpt.com/codex/tasks/task_e_688b104b0f74832c96a56cb765a3f312