### PR TITLE
Improve publication list width

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -5,6 +5,11 @@ img {
   height: auto;
 }
 
+.publication-list {
+  width: 100%;
+  max-width: 100%;
+}
+
 @media (max-width: 600px) {
   body {
     font-size: 1rem;

--- a/publications.md
+++ b/publications.md
@@ -2,6 +2,7 @@
 layout: single
 title: Publications
 permalink: /publications/
+classes: wide
 ---
 
 ## Statistics


### PR DESCRIPTION
## Summary
- make the publications page use the `wide` layout option
- ensure the publication list stretches to full width

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_688b179cd938832c858258522add0efe