### PR TITLE
Remove newline in publication table

### DIFF
--- a/_includes/publication_entry.liquid
+++ b/_includes/publication_entry.liquid
@@ -22,7 +22,7 @@
 
 <li>
   <strong><a href="{{ pub.url }}" target="_blank" rel="noopener">{{ pub.title }}</a></strong><br>
-  <span class="authors">{{ formatted_authors }}</span><br>
+  <span class="authors">{{ formatted_authors }}</span>
   <em>{{ pub.journal }}</em>, {{ pub.year | slice: 0, 4 }}.
   {% if pub.citations and pub.citations > 0 %}
     <span class="citations"> Citations: {{ pub.citations }}</span>


### PR DESCRIPTION
## Summary
- inline the journal name with the author list in publication entries

## Testing
- `npx prettier --write _includes/publication_entry.liquid --parser html` *(fails to format due to Liquid syntax)*

------
https://chatgpt.com/codex/tasks/task_e_688b1a38177c832ca616a68b9e8f4660