### PR TITLE
Improve publication table responsiveness

### DIFF
--- a/_includes/publication_row.liquid
+++ b/_includes/publication_row.liquid
@@ -1,0 +1,26 @@
+{% assign formatted_authors = "" %} {% for author in pub.authors %} {% assign
+parts = author | split: " " %} {% assign initials = "" %} {% for part in parts
+offset:1 %} {% assign initial = part | slice: 0, 1 %} {% assign initials =
+initials | append: initial | append: "." %} {% unless forloop.last %}{% assign
+initials = initials | append: " " %}{% endunless %} {% endfor %} {% assign
+lastname = parts[0] %} {% assign formatted_name = lastname | append: ", " |
+append: initials %} {% if formatted_name contains "Alterman" %} {% assign
+formatted_name = "<strong>Alterman, B. L.</strong>" %} {% endif %} {% assign
+formatted_authors = formatted_authors | append: formatted_name %} {% unless
+forloop.last %}{% assign formatted_authors = formatted_authors | append: ", "
+%}{% endunless %} {% endfor %}
+<tr>
+  <td data-label="Year">{{ pub.year | slice: 0, 4 }}</td>
+  <td data-label="Title">
+    <strong
+      ><a href="{{ pub.url }}" target="_blank" rel="noopener"
+        >{{ pub.title }}</a
+      ></strong
+    >
+  </td>
+  <td data-label="Authors">{{ formatted_authors }}</td>
+  <td data-label="Journal"><em>{{ pub.journal }}</em></td>
+  <td data-label="Citations">
+    {% if pub.citations and pub.citations > 0 %}{{ pub.citations }}{% endif %}
+  </td>
+</tr>

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -15,3 +15,29 @@ img {
     font-size: 0.95rem;
   }
 }
+
+.publication-table-wrapper {
+  overflow-x: auto;
+}
+
+.publication-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.publication-table th,
+.publication-table td {
+  padding: 0.5em;
+  text-align: left;
+}
+
+.publication-table th {
+  background-color: #f2f2f2;
+}
+
+@media (max-width: 600px) {
+  .publication-table th,
+  .publication-table td {
+    font-size: 0.95rem;
+  }
+}

--- a/publications.md
+++ b/publications.md
@@ -17,97 +17,46 @@ This page is automatically generated using data from [NASA ADS](https://ui.adsab
 ## Publication List
 
 {% assign pubs_by_type = site.data.ads_publications | group_by: "publication_type" %}
-{% assign presentations = "" | split: "" %}
-{% assign proceedings = "" | split: "" %}
-{% assign other_groups = "" | split: "" %}
-
-{% for group in pubs_by_type %}
-  {% if group.name == "abstract" %}
-    {% assign presentations = group.items %}
-  {% elsif group.name == "inproceedings" %}
-    {% assign proceedings = group.items %}
-  {% else %}
-    {% assign other_groups = other_groups | push: group %}
-  {% endif %}
-{% endfor %}
-
 {% assign custom_order = "phdthesis,article,inproceedings,abstract,techreport,eprint" | split: "," %}
 
 {% for type in custom_order %}
-  {% assign group = pubs_by_type | where: "name", type | first %}
-  {% if group %}
-    {% if group.name == "phdthesis" %}
-      <h2>PhD Thesis</h2>
-    {% elsif group.name == "article" %}
-      <h2>Refereed Publications</h2>
-    {% elsif group.name == "inproceedings" %}
-      <h2>Conference Proceedings</h2>
-    {% elsif group.name == "abstract" %}
-      <h2>Conference Presentations</h2>
-    {% elsif group.name == "techreport" %}
-      <h2>White Papers</h2>
-    {% elsif group.name == "eprint" %}
-      <h2>Pre-Prints</h2>
-    {% else %}
-      <h2>{{ group.name | capitalize }}</h2>
-    {% endif %}
+{% assign group = pubs_by_type | where: "name", type | first %}
+{% if group %}
+{% if group.name == "phdthesis" %}
 
-    <ul class="publication-list">
-      {% assign pubs = group.items | sort: "year" | reverse %}
-      {% for pub in pubs %}
-        {% include publication_entry.liquid pub=pub %}
-      {% endfor %}
-    </ul>
-  {% endif %}
-{% endfor %}
-    </ul>
-  {% endif %}
-{% endfor %}
-</ul>
-
-<h2>Conference Proceedings</h2>
-<ul class="publication-list">
-  {% assign proceedings_sorted = proceedings | sort: "year" | reverse %}
-  {% for pub in proceedings_sorted %}
-    {% include publication_entry.liquid pub=pub %}
-  {% endfor %}
-</ul>
-
-{% for group in sorted_other_groups %}
-{% if group.name == "article" %}
+<h2>PhD Thesis</h2>
+{% elsif group.name == "article" %}
 <h2>Refereed Publications</h2>
+{% elsif group.name == "inproceedings" %}
+<h2>Conference Proceedings</h2>
+{% elsif group.name == "abstract" %}
+<h2>Conference Presentations</h2>
 {% elsif group.name == "techreport" %}
 <h2>White Papers</h2>
 {% elsif group.name == "eprint" %}
 <h2>Pre-Prints</h2>
-{% elsif group.name == "phdthesis" %}
-<h2>PhD Thesis</h2>
 {% else %}
 <h2>{{ group.name | capitalize }}</h2>
 {% endif %}
 
-  <ul class="publication-list">
+<div class="publication-table-wrapper">
+<table class="publication-table">
+  <thead>
+    <tr>
+      <th>Year</th>
+      <th>Title</th>
+      <th>Authors</th>
+      <th>Journal</th>
+      <th>Citations</th>
+    </tr>
+  </thead>
+  <tbody>
     {% assign pubs = group.items | sort: "year" | reverse %}
     {% for pub in pubs %}
-      {% include publication_entry.liquid pub=pub %}
+      {% include publication_row.liquid pub=pub %}
     {% endfor %}
-  </ul>
+  </tbody>
+</table>
+</div>
+  {% endif %}
 {% endfor %}
-
-<style>
-.publication-list {
-  list-style-type: disc;
-  padding-left: 1.5em;
-}
-.publication-list li {
-  margin-bottom: 1.2em;
-  line-height: 1.5em;
-}
-.publication-list a {
-  text-decoration: none;
-  color: #0645ad;
-}
-.publication-list a:hover {
-  text-decoration: underline;
-}
-</style>


### PR DESCRIPTION
## Summary
- replace publication list with responsive table format
- add `publication_row` Liquid include for table rows
- style `.publication-table` in custom CSS

## Testing
- `npx prettier -w publications.md assets/css/custom.css`
- `npx prettier --parser html -w _includes/publication_row.liquid`


------
https://chatgpt.com/codex/tasks/task_e_688b172da8ac832ca6eb977e8a2e6832