### PR TITLE
Add icon bullets to about page

### DIFF
--- a/about.md
+++ b/about.md
@@ -8,8 +8,20 @@ permalink: /about/
 
 You can find my research profiles and publications at the links below:
 
-- [ORCID: 0000-0001-6673-3432](https://orcid.org/0000-0001-6673-3432)
-- [NASA ADS](https://ui.adsabs.harvard.edu/search/q=orcid%3A0000-0001-6673-3432&sort=date%20desc,%20bibcode%20desc&p_=0)
-- [Google Scholar](https://scholar.google.com/citations?user=yF0j6J8AAAAJ)
-- [arXiv](https://arxiv.org/a/alterman_b_1)
-- [GitHub](https://github.com/blalterman)
+<ul class="profile-links">
+  <li class="orcid">
+    <a href="https://orcid.org/0000-0001-6673-3432">ORCID: 0000-0001-6673-3432</a>
+  </li>
+  <li class="ads">
+    <a href="https://ui.adsabs.harvard.edu/search/q=orcid%3A0000-0001-6673-3432&sort=date%20desc,%20bibcode%20desc&p_=0">NASA ADS</a>
+  </li>
+  <li class="google-scholar">
+    <a href="https://scholar.google.com/citations?user=yF0j6J8AAAAJ">Google Scholar</a>
+  </li>
+  <li class="arxiv">
+    <a href="https://arxiv.org/a/alterman_b_1">arXiv</a>
+  </li>
+  <li class="github">
+    <a href="https://github.com/blalterman">GitHub</a>
+  </li>
+</ul>

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -10,6 +10,43 @@ img {
   max-width: 100%;
 }
 
+.profile-links {
+  list-style: none;
+  padding-left: 0;
+}
+
+.profile-links li {
+  padding-left: 28px;
+  background-repeat: no-repeat;
+  background-size: 20px 20px;
+  background-position: 0 50%;
+  margin-bottom: 0.5rem;
+}
+
+.profile-links li a {
+  text-decoration: none;
+}
+
+.profile-links li.orcid {
+  background-image: url("/assets/images/orcid/ORCID-iD_icon_24x24.png");
+}
+
+.profile-links li.ads {
+  background-image: url("/assets/images/ads/ads.svg");
+}
+
+.profile-links li.google-scholar {
+  background-image: url("/assets/images/google-scholar/google-scholar.svg");
+}
+
+.profile-links li.arxiv {
+  background-image: url("/assets/images/arxiv/arxiv.svg");
+}
+
+.profile-links li.github {
+  background-image: url("/assets/images/github/github-mark.svg");
+}
+
 @media (max-width: 600px) {
   body {
     font-size: 1rem;


### PR DESCRIPTION
## Summary
- add icon bullets to research profile links on `about.md`
- add CSS for icon-based bullet styling

## Testing
- `prettier -w about.md assets/css/custom.css`

------
https://chatgpt.com/codex/tasks/task_e_688b1feff080832ca33397ae563371f2