### PR TITLE
Revert image bullets on About page

### DIFF
--- a/about.md
+++ b/about.md
@@ -6,20 +6,8 @@ permalink: /about/
 
 You can find my research profiles and publications at the links below:
 
-<ul class="profile-links">
-  <li class="orcid">
-    <a href="https://orcid.org/0000-0001-6673-3432">ORCID: 0000-0001-6673-3432</a>
-  </li>
-  <li class="ads">
-    <a href="https://ui.adsabs.harvard.edu/search/q=orcid%3A0000-0001-6673-3432&sort=date%20desc,%20bibcode%20desc&p_=0">NASA ADS</a>
-  </li>
-  <li class="google-scholar">
-    <a href="https://scholar.google.com/citations?user=yF0j6J8AAAAJ">Google Scholar</a>
-  </li>
-  <li class="arxiv">
-    <a href="https://arxiv.org/a/alterman_b_1">arXiv</a>
-  </li>
-  <li class="github">
-    <a href="https://github.com/blalterman">GitHub</a>
-  </li>
-</ul>
+- [ORCID: 0000-0001-6673-3432](https://orcid.org/0000-0001-6673-3432)
+- [NASA ADS](https://ui.adsabs.harvard.edu/search/q=orcid%3A0000-0001-6673-3432&sort=date%20desc,%20bibcode%20desc&p_=0)
+- [Google Scholar](https://scholar.google.com/citations?user=yF0j6J8AAAAJ)
+- [arXiv](https://arxiv.org/a/alterman_b_1)
+- [GitHub](https://github.com/blalterman)

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -5,56 +5,9 @@ img {
   height: auto;
 }
 
-.profile-links {
-  list-style: none;
-  padding-left: 0;
-}
-
-.profile-links li {
-  padding-left: 28px;
-  background-repeat: no-repeat;
-  background-size: 20px 20px;
-  background-position: 0 50%;
-  margin-bottom: 0.5rem;
-}
-
-.profile-links li a {
-  text-decoration: none;
-}
-
-.profile-links li.orcid {
-  background-image: url("/assets/images/orcid/ORCID-iD_icon_24x24.png");
-}
-
-.profile-links li.ads {
-  background-image: url("/assets/images/ads/ads.svg");
-}
-
-.profile-links li.google-scholar {
-  background-image: url("/assets/images/google-scholar/google-scholar.svg");
-}
-
-.profile-links li.arxiv {
-  background-image: url("/assets/images/arxiv/arxiv.svg");
-}
-
-.profile-links li.github {
-  background-image: url("/assets/images/github/github-mark.svg");
-  
 .publication-list {
   width: 100%;
   max-width: 100%;
-}
-  
-table {
-  width: 100%;
-  max-width: 100%;
-  border-collapse: collapse;
-}
-
-.publications-page .page__inner-wrap {
-  max-width: 100%;
-  width: 100%;
 }
 
 @media (max-width: 600px) {
@@ -65,10 +18,6 @@ table {
   }
   .publication-list li {
     font-size: 0.95rem;
-  }
-  table {
-    display: block;
-    overflow-x: auto;
   }
 }
 


### PR DESCRIPTION
## Summary
- revert bullets in about.md back to regular markdown list
- revert CSS file to remove list icon styles

## Testing
- `pytest -q`
- `prettier -w about.md assets/css/custom.css`


------
https://chatgpt.com/codex/tasks/task_e_688b224ed4c4832ca6972e7e5c38f61c