### PR TITLE
Add logos to about page links

### DIFF
--- a/about.md
+++ b/about.md
@@ -6,8 +6,8 @@ permalink: /about/
 
 You can find my research profiles and publications at the links below:
 
-- [ORCID: 0000-0001-6673-3432](https://orcid.org/0000-0001-6673-3432)
-- [NASA ADS](https://ui.adsabs.harvard.edu/search/q=orcid%3A0000-0001-6673-3432&sort=date%20desc,%20bibcode%20desc&p_=0)
-- [Google Scholar](https://scholar.google.com/citations?user=yF0j6J8AAAAJ)
-- [arXiv](https://arxiv.org/a/alterman_b_1)
-- [GitHub](https://github.com/blalterman)
+- <img src="/assets/images/orcid/ORCID-iD_icon_24x24.png" alt="ORCID logo" width="20" height="20"> [ORCID: 0000-0001-6673-3432](https://orcid.org/0000-0001-6673-3432)
+- <img src="/assets/images/ads/ads.svg" alt="NASA ADS logo" width="20" height="20"> [NASA ADS](https://ui.adsabs.harvard.edu/search/q=orcid%3A0000-0001-6673-3432&sort=date%20desc,%20bibcode%20desc&p_=0)
+- <img src="/assets/images/google-scholar/google-scholar.svg" alt="Google Scholar logo" width="20" height="20"> [Google Scholar](https://scholar.google.com/citations?user=yF0j6J8AAAAJ)
+- <img src="/assets/images/arxiv/arxiv.svg" alt="arXiv logo" width="20" height="20"> [arXiv](https://arxiv.org/a/alterman_b_1)
+- <img src="/assets/images/github/github-mark.svg" alt="GitHub logo" width="20" height="20"> [GitHub](https://github.com/blalterman)


### PR DESCRIPTION
## Summary
- show logos next to profile links on `about.md`

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile)*
- `mdformat about.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b28f5b930832c8b48107022c7a2d2