### PR TITLE
Bold citation counts in publication entries

### DIFF
--- a/_includes/publication_entry.liquid
+++ b/_includes/publication_entry.liquid
@@ -25,6 +25,6 @@
   <span class="authors">{{ formatted_authors }}</span>
   <em>{{ pub.journal }}</em>, {{ pub.year | slice: 0, 4 }}.
   {% if pub.citations and pub.citations > 0 %}
-    <span class="citations"> Citations: {{ pub.citations }}</span>
+    <span class="citations"> Citations: <strong>{{ pub.citations }}</strong></span>
   {% endif %}
 </li>


### PR DESCRIPTION
## Summary
- format citation counts with `<strong>` in publication entries

## Testing
- `prettier --write _includes/publication_entry.liquid` *(fails: No parser could be inferred)*

------
https://chatgpt.com/codex/tasks/task_e_688b310198cc832c8f114ac31a4e45f7