### PR TITLE
Fix ADS metrics request path

### DIFF
--- a/scripts/fetch_ads_citations_by_year.py
+++ b/scripts/fetch_ads_citations_by_year.py
@@ -28,7 +28,7 @@ nonrefereed_citations = defaultdict(int)
 
 print("Downloading citation data by year...")
 for i, bibcode in enumerate(bibcodes, 1):
-    url = f"https://api.adsabs.harvard.edu/v1/metrics?bibcode={bibcode}"
+    url = f"https://api.adsabs.harvard.edu/v1/metrics/{bibcode}"
     response = requests.get(url, headers=headers)
     if response.status_code != 200:
         print(f"Failed to get metrics for ({i}) {bibcode}")


### PR DESCRIPTION
## Summary
- correct ADS metrics endpoint path

## Testing
- `python -m py_compile scripts/fetch_ads_citations_by_year.py`
- `black scripts/fetch_ads_citations_by_year.py`

------
https://chatgpt.com/codex/tasks/task_e_688b35ea8a78832c808e6ed701da0928