### PR TITLE
Add two-column layout to about page

### DIFF
--- a/about.md
+++ b/about.md
@@ -11,3 +11,22 @@ You can find my research profiles and publications at the links below:
 - <img src="/assets/images/google-scholar/google-scholar.svg" alt="Google Scholar logo" width="20" height="20"> [Google Scholar](https://scholar.google.com/citations?user=yF0j6J8AAAAJ)
 - <img src="/assets/images/arxiv/arxiv.svg" alt="arXiv logo" width="20" height="20"> [arXiv](https://arxiv.org/a/alterman_b_1)
 - <img src="/assets/images/github/github-mark.svg" alt="GitHub logo" width="20" height="20"> [GitHub](https://github.com/blalterman)
+
+<section class="about-columns">
+  <div class="about-left">
+    <p>Add your introductory paragraph here.</p>
+    <p>Add a second paragraph about yourself here.</p>
+  </div>
+  <div class="about-right">
+    <h2>Education</h2>
+    <ul>
+      <li>Ph.D., Astronomy, Example University, 20XX</li>
+      <li>B.S., Physics, Sample College, 20XX</li>
+    </ul>
+    <h2>Experience</h2>
+    <ul>
+      <li>Research Scientist, XYZ Observatory, 20XX–present</li>
+      <li>Postdoctoral Fellow, ABC Institute, 20XX–20XX</li>
+    </ul>
+  </div>
+</section>

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -33,3 +33,21 @@ img {
 .btn:hover {
   background-color: #005a99;
 }
+
+.about-columns {
+  display: flex;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.about-left,
+.about-right {
+  flex: 1;
+  min-width: 250px;
+}
+
+@media (max-width: 600px) {
+  .about-columns {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Summary
- introduce two-column layout in `about.md`
- style the layout via CSS

## Testing
- `npx markdownlint about.md` *(fails: 403 Forbidden - GET https://registry.npmjs.org/markdownlint)*

------
https://chatgpt.com/codex/tasks/task_e_688bbd26565c832cb8a4d40ba3965872