### PR TITLE
Clean institution names in positions data

### DIFF
--- a/_data/positions.json
+++ b/_data/positions.json
@@ -1,36 +1,36 @@
 [
   {
-    "Company": "NASA Goddard Space Flight Center (GSFC)",
+    "Company": "NASA Goddard Space Flight Center",
     "Position Title": "Research Astrophysicist",
     "Dates": "2024 --",
     "Location": "Greenbelt, MD"
   },
   {
-    "Company": "Southwest Research Institute (SwRI)",
+    "Company": "Southwest Research Institute",
     "Position Title": "Senior Research Scientist",
     "Dates": "2023 -- 2024",
     "Location": "San Antonio, TX"
   },
   {
-    "Company": "Southwest Research Institute (SwRI)",
+    "Company": "Southwest Research Institute",
     "Position Title": "Research Scientist",
     "Dates": "2022 -- 2023",
     "Location": "San Antonio, TX"
   },
   {
-    "Company": "Southwest Research Institute (SwRI)",
+    "Company": "Southwest Research Institute",
     "Position Title": "Postdoctoral Researcher",
     "Dates": "2020 -- 2021",
     "Location": "San Antonio, TX"
   },
   {
-    "Company": "University of Texas at San Antonio (UTSA)",
+    "Company": "University of Texas at San Antonio",
     "Position Title": "Postdoctoral Researcher",
     "Dates": "2021--2022",
     "Location": "San Antonio, TX"
   },
   {
-    "Company": "University of Michigan (UMich)",
+    "Company": "University of Michigan",
     "Position Title": "Research Fellow",
     "Dates": "2019--2020",
     "Location": "Ann Arbor, MI"


### PR DESCRIPTION
## Summary
- remove parenthetical institution abbreviations from positions data

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_688be331b44c832caa3f5cca7a024e95