### PR TITLE
Add headshot to about page

### DIFF
--- a/about.md
+++ b/about.md
@@ -7,6 +7,8 @@ author: B. L. Alterman
 image: /assets/images/headshot.jpg
 ---
 
+<img src="/assets/images/headshot.jpg" alt="Ben Alterman headshot" class="about-headshot" />
+
 Ben Alterman is a Research Astrophysicist at NASA’s Goddard Space Flight Center. He earned his PhD in Applied Physics from the University of Michigan, where he explored how Coulomb collisions and kinetic processes shape the solar wind. After completing a postdoc at the Southwest Research Institute in San Antonio—where he was promoted to Research Scientist—Ben transitioned to civil service at NASA, continuing his work in heliophysics.
 
 Ben is a heliophysics generalist with broad expertise in the thermal and suprathermal solar wind. His research spans multiple spacecraft—including Wind, ACE, Parker Solar Probe, and Solar Orbiter—and multiple timescales, from the second-by-second dynamics of kinetic instabilities to long-term variations across solar cycles. He’s published widely on solar wind composition, solar sources of the solar wind, and the role of helium as a diagnostic of solar activity.

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -82,3 +82,19 @@ article.page {
     padding: 0 0.75rem;
   }
 }
+
+/* Layout for headshot next to introduction text */
+.about-headshot {
+  float: left;
+  width: 150px;
+  margin: 0 1rem 0.5rem 0;
+  border-radius: 4px;
+}
+
+@media (max-width: 600px) {
+  .about-headshot {
+    float: none;
+    display: block;
+    margin: 0 auto 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- show headshot next to the introductory paragraphs on `about.md`
- style `.about-headshot` for floating layout with responsive fallback

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile)*
- `pip install mdformat` *(fails: no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_688be94ff8b0832ca175543af869b553