### PR TITLE
Fix stray closing tag in about page

### DIFF
--- a/about.md
+++ b/about.md
@@ -65,4 +65,5 @@ You can find my research profiles at the links below. My publications are availa
     {% endfor %}
 </tbody>
 </table>
+</div>
 </section>


### PR DESCRIPTION
## Summary
- close the `about-right` div before the closing `section` tag in `about.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688be9954284832ca0c683a717489f2e