### PR TITLE
Add SEO meta descriptions and keywords

### DIFF
--- a/about.md
+++ b/about.md
@@ -2,9 +2,14 @@
 layout: single
 title: About
 permalink: /about/
-description: Ben Alterman is a NASA Research Astrophysicist studying the solar wind, space weather, and humanity’s place in the heliosphere using data from Wind, ACE, Parker Solar Probe, and Solar Orbiter.
+description: B. L. Alterman is a NASA Research Astrophysicist studying the solar wind, space weather, and humanity’s place in the heliosphere using data from Wind, ACE, Parker Solar Probe, and Solar Orbiter.
 author: B. L. Alterman
 image: /assets/images/headshot.jpg
+keywords:
+  - B. L. Alterman
+  - heliophysics
+  - solar wind
+  - space weather
 ---
 
 Ben Alterman is a Research Astrophysicist at NASA’s Goddard Space Flight Center. He earned his PhD in Applied Physics from the University of Michigan, where he explored how Coulomb collisions and kinetic processes shape the solar wind. After completing a postdoc at the Southwest Research Institute in San Antonio—where he was promoted to Research Scientist—Ben transitioned to civil service at NASA, continuing his work in heliophysics.

--- a/index.html
+++ b/index.html
@@ -1,6 +1,13 @@
 ---
 layout: single
 title: Home
+description: B. L. Alterman's personal research website featuring heliophysics publications and projects.
+keywords:
+  - B. L. Alterman
+  - heliophysics
+  - solar wind
+  - space weather
+  - research
 ---
 
 <section>

--- a/publications.md
+++ b/publications.md
@@ -3,6 +3,12 @@ layout: single
 title: Publications
 permalink: /publications/
 classes: wide publications-page
+description: Comprehensive list of B. L. Alterman's publications with citation metrics from NASA ADS.
+keywords:
+  - publications
+  - research papers
+  - NASA ADS
+  - heliophysics
 ---
 
 ## Statistics

--- a/research.md
+++ b/research.md
@@ -2,6 +2,12 @@
 layout: single
 title: Research
 permalink: /research/
+description: Overview of current heliophysics research projects and collaborations.
+keywords:
+  - research
+  - heliophysics
+  - solar wind
+  - space weather
 ---
 
 ## Research


### PR DESCRIPTION
## Summary
- add meta descriptions and keywords to index, about, research, and publications pages for Jekyll SEO tag
- change 'Ben Alterman' to 'B. L. Alterman' in metadata

## Testing
- `jekyll build` *(fails: command not found)*
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688be9786f68832c8d4835c380867d2f